### PR TITLE
Adds #[doc(hidden)] to typetag_name and typetag_register.

### DIFF
--- a/impl/src/tagged_impl.rs
+++ b/impl/src/tagged_impl.rs
@@ -52,6 +52,7 @@ pub(crate) fn expand(args: ImplArgs, mut input: ItemImpl, mode: Mode) -> TokenSt
 fn augment_impl(input: &mut ItemImpl, name: &TokenStream, mode: Mode) {
     if mode.ser {
         input.items.push(parse_quote! {
+            #[doc(hidden)]
             fn typetag_name(&self) -> &'static str {
                 #name
             }

--- a/impl/src/tagged_trait.rs
+++ b/impl/src/tagged_trait.rs
@@ -143,6 +143,7 @@ fn build_registry(input: &ItemTrait) -> TokenStream {
         typetag::inventory::collect!(TypetagRegistration);
 
         impl dyn #object {
+            #[doc(hidden)]
             pub fn typetag_register(name: &'static str, deserializer: TypetagFn) -> TypetagRegistration {
                 TypetagRegistration { name, deserializer }
             }


### PR DESCRIPTION
Resolves #9.

Adding `#![deny(missing_docs)]` to the tests doesn't seem to have an effect, possibly related to https://github.com/rust-lang/rust/issues/24584.