### PR TITLE
[NEED HELP] Partial implementation of switch to linkme.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ members = ["impl"]
 
 [dependencies]
 erased-serde = "0.3"
-inventory = "0.1"
 lazy_static = "1.0"
+linkme = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 typetag-impl = { version = "=0.1.4", path = "impl" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,16 +275,15 @@
 //!
 //! - *Then how does it work?*
 //!
-//!   We use the [`inventory`] crate to produce a registry of impls of your
-//!   trait, which is built on the [`ctor`] crate to hook up initialization
-//!   functions that insert into the registry. The first `Box<dyn Trait>`
-//!   deserialization will perform the work of iterating the registry and
-//!   building a map of tags to deserialization functions. Subsequent
-//!   deserializations find the right deserialization function in that map. The
-//!   [`erased-serde`] crate is also involved, to do this all in a way that does
-//!   not break object safety.
+//!   We use the [`linkme`] crate to produce a registry of impls of your
+//!   trait, collected by the linker into a contiguous section in the binary.
+//!   The first `Box<dyn Trait>` deserialization will perform the work of
+//!   iterating the registry and building a map of tags to deserialization
+//!   functions. Subsequent deserializations find the right deserialization
+//!   function in that map. The [`erased-serde`] crate is also involved, to do
+//!   this all in a way that does not break object safety.
 //!
-//! [`inventory`]: https://github.com/dtolnay/inventory
+//! [`linkme`]: https://github.com/dtolnay/linkme
 //! [`ctor`]: https://github.com/mmastrac/rust-ctor
 //! [`erased-serde`]: https://github.com/dtolnay/erased-serde
 
@@ -293,7 +292,7 @@ pub use typetag_impl::*;
 
 // Not public API. Used by generated code.
 #[doc(hidden)]
-pub use inventory;
+pub use linkme;
 
 // Not public API. Used by generated code.
 #[doc(hidden)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -14,13 +14,13 @@ mod externally_tagged {
     use super::{A, B};
 
     #[typetag::serde]
-    trait Trait {
+    trait TraitOne {
         fn assert_a_is_11(&self);
         fn assert_b_is_11(&self);
     }
 
     #[typetag::serde]
-    impl Trait for A {
+    impl TraitOne for A {
         fn assert_a_is_11(&self) {
             assert_eq!(self.a, 11);
         }
@@ -30,7 +30,7 @@ mod externally_tagged {
     }
 
     #[typetag::serde]
-    impl Trait for B {
+    impl TraitOne for B {
         fn assert_a_is_11(&self) {
             panic!("is not A!");
         }
@@ -41,7 +41,7 @@ mod externally_tagged {
 
     #[test]
     fn test_json_serialize() {
-        let trait_object = &A { a: 11 } as &dyn Trait;
+        let trait_object = &A { a: 11 } as &dyn TraitOne;
         let json = serde_json::to_string(trait_object).unwrap();
         let expected = r#"{"A":{"a":11}}"#;
         assert_eq!(json, expected);
@@ -50,15 +50,15 @@ mod externally_tagged {
     #[test]
     fn test_json_deserialize() {
         let json = r#"{"B":{"b":11}}"#;
-        let trait_object: Box<dyn Trait> = serde_json::from_str(json).unwrap();
+        let trait_object: Box<dyn TraitOne> = serde_json::from_str(json).unwrap();
         trait_object.assert_b_is_11();
     }
 
     #[test]
     fn test_bincode_round_trip() {
-        let trait_object = &A { a: 11 } as &dyn Trait;
+        let trait_object = &A { a: 11 } as &dyn TraitOne;
         let bytes = bincode::serialize(trait_object).unwrap();
-        let trait_object: Box<dyn Trait> = bincode::deserialize(&bytes).unwrap();
+        let trait_object: Box<dyn TraitOne> = bincode::deserialize(&bytes).unwrap();
         trait_object.assert_a_is_11();
     }
 }
@@ -67,13 +67,13 @@ mod internally_tagged {
     use super::{A, B};
 
     #[typetag::serde(tag = "type")]
-    trait Trait {
+    trait TraitTwo {
         fn assert_a_is_11(&self);
         fn assert_b_is_11(&self);
     }
 
     #[typetag::serde]
-    impl Trait for A {
+    impl TraitTwo for A {
         fn assert_a_is_11(&self) {
             assert_eq!(self.a, 11);
         }
@@ -83,7 +83,7 @@ mod internally_tagged {
     }
 
     #[typetag::serde]
-    impl Trait for B {
+    impl TraitTwo for B {
         fn assert_a_is_11(&self) {
             panic!("is not A!");
         }
@@ -94,7 +94,7 @@ mod internally_tagged {
 
     #[test]
     fn test_json_serialize() {
-        let trait_object = &A { a: 11 } as &dyn Trait;
+        let trait_object = &A { a: 11 } as &dyn TraitTwo;
         let json = serde_json::to_string(trait_object).unwrap();
         let expected = r#"{"type":"A","a":11}"#;
         assert_eq!(json, expected);
@@ -103,15 +103,15 @@ mod internally_tagged {
     #[test]
     fn test_json_deserialize() {
         let json = r#"{"type":"B","b":11}"#;
-        let trait_object: Box<dyn Trait> = serde_json::from_str(json).unwrap();
+        let trait_object: Box<dyn TraitTwo> = serde_json::from_str(json).unwrap();
         trait_object.assert_b_is_11();
     }
 
     #[test]
     fn test_bincode_round_trip() {
-        let trait_object = &A { a: 11 } as &dyn Trait;
+        let trait_object = &A { a: 11 } as &dyn TraitTwo;
         let bytes = bincode::serialize(trait_object).unwrap();
-        let trait_object: Box<dyn Trait> = bincode::deserialize(&bytes).unwrap();
+        let trait_object: Box<dyn TraitTwo> = bincode::deserialize(&bytes).unwrap();
         trait_object.assert_a_is_11();
     }
 }


### PR DESCRIPTION
Attempt at doing https://github.com/dtolnay/typetag/issues/15.

Changes:

* Switched `inventory` calls to `distributed_slice`s.
* Renamed traits in test to be different -- same-named macros cannot be exported from the same crate, this is a WIP hack.
* Change the dummy `const` wrapper to a `mod` wrapper -- the `linkme` distributed slice macro cannot be referenced when inside the const.

This doesn't work yet -- unsure why the module static is not resolved when running `cargo test --all`:

```rust
error[E0433]: failed to resolve: could not find `TRAITONE_TYPETAG_REGISTRATIONS` in `_TraitOne_registry`
  --> tests/test.rs:22:5
   |
22 |     #[typetag::serde]
   |     ^^^^^^^^^^^^^^^^^ could not find `TRAITONE_TYPETAG_REGISTRATIONS` in `_TraitOne_registry`
```

`cargo expand` shows that it exists:

```rust
mod externally_tagged {
    // ..

    #[allow(non_upper_case_globals)]
    #[macro_use]
    mod _TraitOne_registry {
        // ..
        pub static TRAITONE_TYPETAG_REGISTRATIONS: linkme::DistributedSlice<
            [fn() -> TypetagRegistration],
        > = {
            // ..
        };

    }

    // ..
}
```

Anyone: feel free to work on this. I'm not continuing this attempt yet as I can't figure out what's wrong -- maybe it's to do with macro invocation and type resolution order, but that's beyond my current understanding.