### PR TITLE
Parse type name from macro metavariable

### DIFF
--- a/impl/src/tagged_impl.rs
+++ b/impl/src/tagged_impl.rs
@@ -67,11 +67,16 @@ fn augment_impl(input: &mut ItemImpl, name: &TokenStream, mode: Mode) {
     }
 }
 
-fn type_name(ty: &Type) -> Option<String> {
-    match ty {
-        Type::Path(TypePath { qself: None, path }) => {
-            Some(path.segments.last().unwrap().ident.to_string())
+fn type_name(mut ty: &Type) -> Option<String> {
+    loop {
+        match ty {
+            Type::Path(TypePath { qself: None, path }) => {
+                return Some(path.segments.last().unwrap().ident.to_string());
+            }
+            Type::Group(group) => {
+                ty = &group.elem;
+            }
+            _ => return None,
         }
-        _ => None,
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -242,3 +242,19 @@ mod generic {
     #[typetag::serialize]
     trait Generic<T> {}
 }
+
+mod macro_expanded {
+    use super::A;
+
+    #[typetag::serde]
+    trait Trait {}
+
+    macro_rules! impl_trait {
+        ($ty:ty) => {
+            #[typetag::serde]
+            impl Trait for $ty {}
+        };
+    }
+
+    impl_trait!(A);
+}


### PR DESCRIPTION
Fixes errors that look like this:

```console
error: use #[typetag::serde(name = "...")] to specify a unique name
   --> tests/test.rs:255:28
    |
255 |             impl Trait for $ty {}
    |                            ^^^
...
259 |     impl_trait!(A);
    |     --------------- in this macro invocation
```

https://github.com/rust-lang/rust/issues/72545