### PR TITLE
Support runtime registration for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,17 @@ categories = ["encoding"]
 readme = "README.md"
 edition = "2018"
 
+[features]
+default = ["inventory"]
+runtime = ["typetag-impl/runtime"]
+
 [workspace]
 members = ["impl"]
 
 [dependencies]
+cfg-if = "1.0.0"
 erased-serde = "0.3"
-inventory = "0.1"
+inventory = { version = "0.1", optional = true }
 lazy_static = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 typetag-impl = { version = "=0.1.7", path = "impl" }

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -9,10 +9,15 @@ documentation = "https://docs.rs/typetag"
 readme = "README.md"
 edition = "2018"
 
+[features]
+default = []
+runtime = []
+
 [lib]
 proc-macro = true
 
 [dependencies]
+cfg-if = "1.0.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/impl/src/tagged_impl.rs
+++ b/impl/src/tagged_impl.rs
@@ -23,27 +23,18 @@ pub(crate) fn expand(args: ImplArgs, mut input: ItemImpl, mode: Mode) -> TokenSt
 
     augment_impl(&mut input, &name, mode);
 
-    let object = &input.trait_.as_ref().unwrap().1;
-    let this = &input.self_ty;
+    cfg_if::cfg_if! {
+        if #[cfg(feature="runtime")] {
+            augment_impl_register(&mut input, &name, mode);
 
-    let mut expanded = quote! {
-        #input
-    };
+            let expanded = quote! { #input };
+        } else {
+            let mut expanded = quote! {
+                #input
+            };
 
-    if mode.de {
-        expanded.extend(quote! {
-            typetag::inventory::submit! {
-                #![crate = typetag]
-                <dyn #object>::typetag_register(
-                    #name,
-                    |deserializer| std::result::Result::Ok(
-                        std::boxed::Box::new(
-                            typetag::erased_serde::deserialize::<#this>(deserializer)?
-                        ),
-                    ),
-                )
-            }
-        });
+            register_inventory(&mut input, &name, &mut expanded);
+        }
     }
 
     expanded
@@ -65,6 +56,49 @@ fn augment_impl(input: &mut ItemImpl, name: &TokenStream, mode: Mode) {
             fn typetag_deserialize(&self) {}
         });
     }
+}
+
+
+#[cfg(feature="runtime")]
+fn augment_impl_register(input: &mut ItemImpl, name: &TokenStream, mode: Mode) {
+    let object = &input.trait_.as_ref().unwrap().1;
+    let this = &input.self_ty;
+
+    if mode.de {
+        input.items.push(parse_quote! {
+            #[doc(hidden)]
+            fn register() {
+                <dyn #object>::typetag_register(
+                    #name,
+                    |deserializer| std::result::Result::Ok(
+                        std::boxed::Box::new(
+                            typetag::erased_serde::deserialize::<#this>(deserializer)?
+                        ),
+                    ),
+                )
+            }
+        });
+    }
+}
+
+#[cfg(not(feature="runtime"))]
+fn register_inventory(input: &mut ItemImpl, name: &TokenStream, expanded: &mut TokenStream) {
+    let object = &input.trait_.as_ref().unwrap().1;
+    let this = &input.self_ty;
+
+    expanded.extend(quote! {
+        typetag::inventory::submit! {
+            #![crate = typetag]
+            <dyn #object>::typetag_register(
+                #name,
+                |deserializer| std::result::Result::Ok(
+                    std::boxed::Box::new(
+                        typetag::erased_serde::deserialize::<#this>(deserializer)?
+                    ),
+                ),
+            )
+        }
+    });
 }
 
 fn type_name(mut ty: &Type) -> Option<String> {

--- a/impl/src/tagged_trait.rs
+++ b/impl/src/tagged_trait.rs
@@ -125,9 +125,26 @@ fn augment_trait(input: &mut ItemTrait, mode: Mode) {
             #[doc(hidden)]
             fn typetag_deserialize(&self);
         });
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature="runtime")] {
+                input.items.push(parse_quote! {
+                    #[doc(hidden)]
+                    fn register() where Self: Sized;
+                });
+            } else {
+                // If not using runtime registration, let it be a no-op.
+                input.items.push(parse_quote! {
+                    #[doc(hidden)]
+                    fn register() where Self: Sized {}
+                });
+
+            }
+        }
     }
 }
 
+#[cfg(not(feature = "runtime"))]
 fn build_registry(input: &ItemTrait) -> TokenStream {
     let object = &input.ident;
 
@@ -166,6 +183,47 @@ fn build_registry(input: &ItemTrait) -> TokenStream {
                 }
                 names.sort_unstable();
                 typetag::Registry { map, names }
+            };
+        }
+    }
+}
+
+#[cfg(feature = "runtime")]
+fn build_registry(input: &ItemTrait) -> TokenStream {
+    let object = &input.ident;
+
+    quote! {
+        type TypetagStrictest = <dyn #object as typetag::Strictest>::Object;
+        type TypetagFn = typetag::DeserializeFn<TypetagStrictest>;
+
+        pub struct TypetagRegistration {
+            name: &'static str,
+            deserializer: TypetagFn,
+        }
+
+        impl dyn #object {
+            #[doc(hidden)]
+            pub fn typetag_register(name: &'static str, deserializer: TypetagFn) -> () {
+                let registered = TypetagRegistration { name, deserializer };
+
+                let mut registry = TYPETAG.write().unwrap();
+                match registry.map.entry(registered.name) {
+                    std::collections::btree_map::Entry::Vacant(entry) => {
+                        entry.insert(std::option::Option::Some(registered.deserializer));
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut entry) => {
+                        entry.insert(std::option::Option::None);
+                    }
+                }
+                registry.names.push(registered.name);
+                registry.names.sort_unstable();
+            }
+        }
+
+
+        typetag::lazy_static::lazy_static! {
+            static ref TYPETAG: typetag::Registry<TypetagStrictest> = {
+                typetag::Registry::default()
             };
         }
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use crate::{DeserializeFn, Registry};
+use crate::{DeserializeFn, DeserializerRegistry, Registry};
 use serde::de::{self, DeserializeSeed, Deserializer, Expected, Visitor};
 use std::fmt;
 
@@ -18,14 +18,7 @@ impl<'de, 'a, T: ?Sized + 'static> Visitor<'de> for MapLookupVisitor<'a, T> {
     where
         E: serde::de::Error,
     {
-        match self.registry.map.get(key) {
-            Some(Some(value)) => Ok(*value),
-            Some(None) => Err(de::Error::custom(format_args!(
-                "non-unique tag of {}: {:?}",
-                self.expected, key
-            ))),
-            None => Err(de::Error::unknown_variant(key, &self.registry.names)),
-        }
+        self.registry.get_deserializer(key, self.expected)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,7 @@
 pub use typetag_impl::*;
 
 // Not public API. Used by generated code.
+#[cfg(feature="inventory")]
 #[doc(hidden)]
 pub use inventory;
 
@@ -336,6 +337,10 @@ pub mod internally;
 #[doc(hidden)]
 pub mod adjacently;
 
+// Not public API. Used by generated code.
+#[doc(hidden)]
+pub mod registry;
+
 mod content;
 mod de;
 mod ser;
@@ -344,14 +349,9 @@ mod ser;
 #[doc(hidden)]
 pub type DeserializeFn<T> = fn(&mut dyn erased_serde::Deserializer) -> erased_serde::Result<Box<T>>;
 
-use std::collections::BTreeMap;
-
 // Not public API. Used by generated code.
 #[doc(hidden)]
-pub struct Registry<T: ?Sized> {
-    pub map: BTreeMap<&'static str, Option<DeserializeFn<T>>>,
-    pub names: Vec<&'static str>,
-}
+pub use registry::*;
 
 // Object-safe trait bound inserted by typetag serialization. We want this just
 // so the serialization requirement appears on rustdoc's view of your trait.

--- a/src/registry/common.rs
+++ b/src/registry/common.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeMap;
+
+use serde::de::{self, Expected};
+
+use crate::{DeserializeFn, DeserializerRegistry};
+
+pub struct Registry<T: ?Sized> {
+    pub map: BTreeMap<&'static str, Option<DeserializeFn<T>>>,
+    pub names: Vec<&'static str>,
+}
+
+#[cfg(feature = "runtime")]
+impl<T: ?Sized> Default for Registry<T> {
+    #[must_use]
+    fn default() -> Self {
+        let map = std::collections::BTreeMap::new();
+        let names = std::vec::Vec::new();
+
+        Self { map, names }
+    }
+}
+
+impl<T: ?Sized> DeserializerRegistry<T> for Registry<T> {
+    fn get_deserializer<E>(
+        &'static self,
+        key: &str,
+        expected: &dyn Expected,
+    ) -> Result<DeserializeFn<T>, E>
+    where
+        E: serde::de::Error,
+    {
+        match self.map.get(key) {
+            Some(Some(value)) => Ok(*value),
+            Some(None) => Err(de::Error::custom(format_args!(
+                "non-unique tag of {}: {:?}",
+                expected, key
+            ))),
+            None => Err(de::Error::unknown_variant(key, &self.names)),
+        }
+    }
+}

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,0 +1,12 @@
+pub(crate) mod common;
+#[cfg(feature="runtime")]
+pub(crate) mod runtime;
+pub(crate) mod registry_trait;
+
+pub use self::registry_trait::*;
+
+#[cfg(feature="runtime")]
+pub use self::runtime::*;
+
+#[cfg(not(feature="runtime"))]
+pub use self::common::*;

--- a/src/registry/registry_trait.rs
+++ b/src/registry/registry_trait.rs
@@ -1,0 +1,12 @@
+use crate::DeserializeFn;
+use serde::de::Expected;
+
+pub trait DeserializerRegistry<T: ?Sized> {
+    fn get_deserializer<E>(
+        &'static self,
+        key: &str,
+        expected: &dyn Expected,
+    ) -> Result<DeserializeFn<T>, E>
+    where
+        E: serde::de::Error;
+}

--- a/src/registry/runtime.rs
+++ b/src/registry/runtime.rs
@@ -1,0 +1,50 @@
+use std::sync::RwLock;
+
+use crate::{DeserializeFn, DeserializerRegistry};
+use serde::de::{self, Expected};
+
+use super::common::Registry as InnerRegistry;
+
+pub struct Registry<T: ?Sized>(RwLock<InnerRegistry<T>>);
+
+impl<T: ?Sized> Default for Registry<T> {
+    #[must_use]
+    fn default() -> Self {
+        Registry(RwLock::new(InnerRegistry::default()))
+    }
+}
+
+impl<T: ?Sized> std::ops::Deref for Registry<T> {
+    type Target = RwLock<InnerRegistry<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: ?Sized> DeserializerRegistry<T> for Registry<T> {
+    fn get_deserializer<E>(
+        &'static self,
+        key: &str,
+        expected: &dyn Expected,
+    ) -> Result<DeserializeFn<T>, E>
+    where
+        E: serde::de::Error,
+    {
+        let registry = self
+            .read()
+            .map_err(|_| de::Error::custom("Unable to acquire lock, registry lock poisoned."))?;
+
+        match registry.map.get(key) {
+            Some(Some(value)) => Ok(*value),
+            Some(None) => Err(de::Error::custom(format_args!(
+                "non-unique tag of {}: {:?}",
+                expected, key
+            ))),
+            None => Err(de::Error::unknown_variant(
+                key,
+                &["dynamic list, unable to list variants"],
+            )),
+        }
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -39,8 +39,23 @@ mod externally_tagged {
         }
     }
 
+    cfg_if::cfg_if! {
+        if #[cfg(feature="runtime")] {
+            static REGISTER_ONCE: std::sync::Once = std::sync::Once::new();
+            fn register_all() {
+                REGISTER_ONCE.call_once(|| {
+                    <A as Trait>::register();
+                    <B as Trait>::register();
+                });
+            }
+        } else {
+            fn register_all() {}
+        }
+    }
+
     #[test]
     fn test_json_serialize() {
+        register_all();
         let trait_object = &A { a: 11 } as &dyn Trait;
         let json = serde_json::to_string(trait_object).unwrap();
         let expected = r#"{"A":{"a":11}}"#;
@@ -49,6 +64,7 @@ mod externally_tagged {
 
     #[test]
     fn test_json_deserialize() {
+        register_all();
         let json = r#"{"B":{"b":11}}"#;
         let trait_object: Box<dyn Trait> = serde_json::from_str(json).unwrap();
         trait_object.assert_b_is_11();
@@ -56,6 +72,7 @@ mod externally_tagged {
 
     #[test]
     fn test_bincode_round_trip() {
+        register_all();
         let trait_object = &A { a: 11 } as &dyn Trait;
         let bytes = bincode::serialize(trait_object).unwrap();
         let trait_object: Box<dyn Trait> = bincode::deserialize(&bytes).unwrap();
@@ -92,8 +109,23 @@ mod internally_tagged {
         }
     }
 
+    cfg_if::cfg_if! {
+        if #[cfg(feature="runtime")] {
+            static REGISTER_ONCE: std::sync::Once = std::sync::Once::new();
+            fn register_all() {
+                REGISTER_ONCE.call_once(|| {
+                    <A as Trait>::register();
+                    <B as Trait>::register();
+                });
+            }
+        } else {
+            fn register_all() {}
+        }
+    }
+
     #[test]
     fn test_json_serialize() {
+        register_all();
         let trait_object = &A { a: 11 } as &dyn Trait;
         let json = serde_json::to_string(trait_object).unwrap();
         let expected = r#"{"type":"A","a":11}"#;
@@ -102,6 +134,7 @@ mod internally_tagged {
 
     #[test]
     fn test_json_deserialize() {
+        register_all();
         let json = r#"{"type":"B","b":11}"#;
         let trait_object: Box<dyn Trait> = serde_json::from_str(json).unwrap();
         trait_object.assert_b_is_11();
@@ -109,6 +142,7 @@ mod internally_tagged {
 
     #[test]
     fn test_bincode_round_trip() {
+        register_all();
         let trait_object = &A { a: 11 } as &dyn Trait;
         let bytes = bincode::serialize(trait_object).unwrap();
         let trait_object: Box<dyn Trait> = bincode::deserialize(&bytes).unwrap();
@@ -145,8 +179,23 @@ mod adjacently_tagged {
         }
     }
 
+    cfg_if::cfg_if! {
+        if #[cfg(feature="runtime")] {
+            static REGISTER_ONCE: std::sync::Once = std::sync::Once::new();
+            fn register_all() {
+                REGISTER_ONCE.call_once(|| {
+                    <A as Trait>::register();
+                    <B as Trait>::register();
+                });
+            }
+        } else {
+            fn register_all() {}
+        }
+    }
+
     #[test]
     fn test_json_serialize() {
+        register_all();
         let trait_object = &A { a: 11 } as &dyn Trait;
         let json = serde_json::to_string(trait_object).unwrap();
         let expected = r#"{"type":"A","content":{"a":11}}"#;
@@ -155,6 +204,7 @@ mod adjacently_tagged {
 
     #[test]
     fn test_json_deserialize() {
+        register_all();
         let json = r#"{"type":"B","content":{"b":11}}"#;
         let trait_object: Box<dyn Trait> = serde_json::from_str(json).unwrap();
         trait_object.assert_b_is_11();
@@ -162,6 +212,7 @@ mod adjacently_tagged {
 
     #[test]
     fn test_bincode_round_trip() {
+        register_all();
         let trait_object = &A { a: 11 } as &dyn Trait;
         let bytes = bincode::serialize(trait_object).unwrap();
         let trait_object: Box<dyn Trait> = bincode::deserialize(&bytes).unwrap();


### PR DESCRIPTION
# Problem

WASM targets do not support `ctor` crate, a dependency of `inventory`. Static/pre-main registration also goes against the Rust guidelines (covered elsewhere) that there ought to be no code before main. (Part of the philosophy of explicit is better than implicit, I take it?)

This is an issue and has been reported in #30, #15, and others.

# Possible Solution

Runtime, explicit registration functions.

This adds a feature `runtime` which enables runtime registration of types and removes `inventory`.

This likely isn't up to the coding standard you'd use or how features ought to be used, and I'd appreciate any advice there. I thought about declaring feature `std = ["std", "inventory"]`, but I think inventory works in no_std, non-wasm environments, so I'm not sure if there's a way to _turn off_ `inventory` as a dependency and _enable_ `runtime` as a feature in wasm environments automatically. If there is, that would be fantastic.

The two things I'm most uncertain about are:

* defining a `register` fn on traits, should probably rename that to something less likely to conflict, though it is a **static** method, so it's only callable via `<A as Trait>::register()` where `Trait` has a `#[typetag]` macro-attr
* making it easier for wasm users to use this without having to use no-default-features & features="runtime"
