### PR TITLE
Update to inventory 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["impl"]
 
 [dependencies]
 erased-serde = "0.3"
-inventory = "0.1"
+inventory = "0.2"
 lazy_static = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 typetag-impl = { version = "=0.1.7", path = "impl" }

--- a/impl/src/tagged_impl.rs
+++ b/impl/src/tagged_impl.rs
@@ -33,14 +33,13 @@ pub(crate) fn expand(args: ImplArgs, mut input: ItemImpl, mode: Mode) -> TokenSt
     if mode.de {
         expanded.extend(quote! {
             typetag::inventory::submit! {
-                #![crate = typetag]
                 <dyn #object>::typetag_register(
                     #name,
-                    |deserializer| std::result::Result::Ok(
+                    (|deserializer| std::result::Result::Ok(
                         std::boxed::Box::new(
                             typetag::erased_serde::deserialize::<#this>(deserializer)?
                         ),
-                    ),
+                    )) as typetag::DeserializeFn<<dyn #object as typetag::Strictest>::Object>,
                 )
             }
         });

--- a/impl/src/tagged_trait.rs
+++ b/impl/src/tagged_trait.rs
@@ -136,16 +136,16 @@ fn build_registry(input: &ItemTrait) -> TokenStream {
         type TypetagStrictest = <dyn #object as typetag::Strictest>::Object;
         type TypetagFn = typetag::DeserializeFn<TypetagStrictest>;
 
-        #vis struct TypetagRegistration {
+        #vis struct TypetagRegistration<T> {
             name: &'static str,
-            deserializer: TypetagFn,
+            deserializer: T,
         }
 
-        typetag::inventory::collect!(TypetagRegistration);
+        typetag::inventory::collect!(TypetagRegistration<TypetagFn>);
 
         impl dyn #object {
             #[doc(hidden)]
-            #vis fn typetag_register(name: &'static str, deserializer: TypetagFn) -> TypetagRegistration {
+            #vis const fn typetag_register<T>(name: &'static str, deserializer: T) -> TypetagRegistration<T> {
                 TypetagRegistration { name, deserializer }
             }
         }
@@ -154,7 +154,7 @@ fn build_registry(input: &ItemTrait) -> TokenStream {
             static ref TYPETAG: typetag::Registry<TypetagStrictest> = {
                 let mut map = std::collections::BTreeMap::new();
                 let mut names = std::vec::Vec::new();
-                for registered in typetag::inventory::iter::<TypetagRegistration> {
+                for registered in typetag::inventory::iter::<TypetagRegistration<TypetagFn>> {
                     match map.entry(registered.name) {
                         std::collections::btree_map::Entry::Vacant(entry) => {
                             entry.insert(std::option::Option::Some(registered.deserializer));


### PR DESCRIPTION
Closes #41. Some tricks to work around current limitations of `const fn`s: their signature must not mention a function pointer, mutable reference, or trait object type, even if irrelevant to the runtime behavior of the function.