### PR TITLE
Flexibilization of deserialization

### DIFF
--- a/impl/src/parse.rs
+++ b/impl/src/parse.rs
@@ -1,11 +1,14 @@
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
-use syn::{Attribute, Error, ItemImpl, ItemTrait, LitStr, Token, Visibility};
+use syn::{Attribute, Error, ExprPath, ItemImpl, ItemTrait, LitInt, LitStr, Token, Visibility};
 
 mod kw {
     syn::custom_keyword!(tag);
     syn::custom_keyword!(content);
     syn::custom_keyword!(name);
+    syn::custom_keyword!(compare);
+    syn::custom_keyword!(priority);
+    syn::custom_keyword!(default);
 }
 
 pub enum TraitArgs {
@@ -14,13 +17,48 @@ pub enum TraitArgs {
     Adjacent { tag: LitStr, content: LitStr },
 }
 
+pub enum Priority {
+    Defined(LitInt),
+    Undefined,
+    Default,
+}
+
+impl Priority {
+    pub fn is_default(&self) -> bool {
+        match self {
+            Priority::Default => true,
+            _ => false,
+        }
+    }
+}
+
 pub struct ImplArgs {
     pub name: Option<LitStr>,
+    pub comparison_function: Option<ExprPath>,
+    pub priority: Priority,
 }
 
 pub enum Input {
     Trait(ItemTrait),
     Impl(ItemImpl),
+}
+
+fn parse_argument<T: Parse, U: Parse>(input: &ParseStream) -> Result<U> {
+    input.parse::<T>()?;
+    input.parse::<Token![=]>()?;
+    let result = input.parse()?;
+    if !input.is_empty() {
+        input.parse::<Token![,]>()?;
+    }
+    Ok(result)
+}
+
+fn parse_flag<T: Parse>(input: &ParseStream) -> Result<()> {
+    input.parse::<T>()?;
+    if !input.is_empty() {
+        input.parse::<Token![,]>()?;
+    }
+    Ok(())
 }
 
 impl Parse for Input {
@@ -59,35 +97,54 @@ impl Parse for Input {
 // #[typetag::serde(tag = "type", content = "content")]
 impl Parse for TraitArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        if input.is_empty() {
-            return Ok(TraitArgs::External);
+        let mut tag = None;
+        let mut content = None;
+
+        while !input.is_empty() {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::tag) {
+                tag = Some(parse_argument::<kw::tag, _>(&input)?);
+            } else if lookahead.peek(kw::content) {
+                content = Some(parse_argument::<kw::content, _>(&input)?);
+            }
         }
-        input.parse::<kw::tag>()?;
-        input.parse::<Token![=]>()?;
-        let tag: LitStr = input.parse()?;
-        if input.is_empty() {
-            return Ok(TraitArgs::Internal { tag });
+        match (tag, content) {
+            (None, None) => Ok(TraitArgs::External),
+            (Some(tag), None) => Ok(TraitArgs::Internal { tag }),
+            (Some(tag), Some(content)) => Ok(TraitArgs::Adjacent { tag, content }),
+            (None, Some(content)) => Err(Error::new(
+                content.span(),
+                "Adjacently tagged enumerations must have a tag defined.",
+            )),
         }
-        input.parse::<Token![,]>()?;
-        input.parse::<kw::content>()?;
-        input.parse::<Token![=]>()?;
-        let content: LitStr = input.parse()?;
-        Ok(TraitArgs::Adjacent { tag, content })
     }
 }
 
 // #[typetag::serde]
-// #[typetag::serde(name = "Tag")]
+// #[typetag::serde(name = "Tag", comparison_function = fn(&str)->bool, priority)]
+// #[typetag::serde(name = "Tag", default)]
 impl Parse for ImplArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        let name = if input.is_empty() {
-            None
-        } else {
-            input.parse::<kw::name>()?;
-            input.parse::<Token![=]>()?;
-            let name: LitStr = input.parse()?;
-            Some(name)
+        let mut impl_args = ImplArgs {
+            name: None,
+            comparison_function: None,
+            priority: Priority::Undefined,
         };
-        Ok(ImplArgs { name })
+        while !input.is_empty() {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::name) {
+                impl_args.name = Some(parse_argument::<kw::name, _>(&input)?);
+            } else if lookahead.peek(kw::compare) {
+                impl_args.comparison_function = Some(parse_argument::<kw::compare, _>(&input)?);
+            } else if lookahead.peek(kw::priority) {
+                impl_args.priority = Priority::Defined(parse_argument::<kw::priority, _>(&input)?);
+            } else if lookahead.peek(kw::default) {
+                parse_flag::<kw::default>(&input)?;
+                impl_args.priority = Priority::Default;
+            } else {
+                return Err(lookahead.error());
+            }
+        }
+        Ok(impl_args)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,9 +297,9 @@
 //! [`erased-serde`]: https://github.com/dtolnay/erased-serde
 
 #![allow(
-    clippy::missing_errors_doc,
-    clippy::module_name_repetitions,
-    clippy::unnested_or_patterns
+clippy::missing_errors_doc,
+clippy::module_name_repetitions,
+clippy::unnested_or_patterns
 )]
 
 #[doc(hidden)]
@@ -341,12 +341,23 @@ mod ser;
 #[doc(hidden)]
 pub type DeserializeFn<T> = fn(&mut dyn erased_serde::Deserializer) -> erased_serde::Result<Box<T>>;
 
-use std::collections::BTreeMap;
+#[doc(hidden)]
+pub type ComparisonFn = fn(&str) -> bool;
+
+#[repr(transparent)]
+pub struct WrappedComparisonFn(pub ComparisonFn);
+
+pub struct RegistryEntry<T: ?Sized> {
+    pub name: &'static str,
+    pub priority: isize,
+    pub comparison_function: ComparisonFn,
+    pub deserialize_function: Option<DeserializeFn<T>>,
+}
 
 // Not public API. Used by generated code.
 #[doc(hidden)]
 pub struct Registry<T: ?Sized> {
-    pub map: BTreeMap<&'static str, Option<DeserializeFn<T>>>,
+    pub entries: Vec<RegistryEntry<T>>,
     pub names: Vec<&'static str>,
 }
 


### PR DESCRIPTION
I plan to use this crate for my project.

Unfortunately I need a more flexible processing of the tags for deserialization.
This pull request adds most of the functions I need. I think these may be useful for others as well.

## New functions:

1. Support for compare functions:
This PR can be used to declare comparison functions that are executed instead of a simple string comparison.
This is useful if several keys are to be supported or only a part of a key is relevant for the evaluation.

```rust
#[typetag::serde(compare = trait_take_b)]
impl Trait for B {
}
fn trait_take_b(key: &str) -> bool {
    key.to_string().to_lowercase() == "b"
}
```

2. Support for priorities:
With this PR a priority can be given to a trait implementation, which influences the order of processing. A higher number leads to a higher prioritization.

```rust
#[typetag::serde(priority = 1)]
impl Trait for B {
}
```

3. Support for "default":
The two previous features allow the support of "default" variants for free: a minimally prioritized element with the comparison function "|_|true" satisfies the characteristics of a "default" variant.

```rust
#[typetag::serde(default)]
impl Trait for B {
}
```

4. Support for arbitrary ordering of Proc-Macro arguments:
With the PR it is possible to use the macro arguments in any order. With more possible arguments this can be very helpful.

```rust
#[typetag::serde(compare = trait_take_b, priority = 1)]
impl Trait for B {
}
```

```rust
#[typetag::serde(priority = 1, compare = trait_take_b)]
impl Trait for B {
}
```

## Implementation details:

I changed the use of a Map to a Vector in the registry. This made sense because, on the one hand, the use of comparison methods means that each element has to be tested consecutively in any case. On the other hand, I don't expect such a large amount of different elements here that problems with runtime behavior will arise.

Instead of the original map lookup, the function `|key|key==#name` is now used by default.

## ToDos:

### Testing

This pull request has not yet been completed. I have not yet tested the functions for internally and adjacently tagged enumerations. Corresponding test cases are still missing.
If the approach fits, I will submit them directly. I recommend here to split on several test files to improve the overview.

### Support for key fields

A key matched in the comparison method is of great interest for further processing.
An example:
In a default variant it is very interesting to know which concrete key has matched here. An example implementation could look like this:

```rust
#[derive(Serialize, Deserialize)]
struct Default {
    default: u8,
    key: String,
}
#[typetag::serde(key_field="key")]
trait Trait {
}
#[typetag::serde(default)]
impl Trait for Default {
}
```
I could already implement this so that it works for JSON, but not for Bincode.
Dealing with other edge cases may also be challenging.
Here I would still need support or at least some ideas.

Best regards
Alex