### PR TITLE
Support renaming crate in Cargo.toml, re-exporting macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ repository = "https://github.com/dtolnay/typetag"
 rust-version = "1.62"
 
 [workspace]
-members = ["impl"]
+members = ["impl", "macro"]
 
 [dependencies]
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 inventory = "0.3"
 once_cell = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-typetag-impl = { version = "=0.2.3", path = "impl" }
+typetag-macro = { version = "=0.2.3", path = "macro" }
 
 [dev-dependencies]
 bincode = "1.0"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/typetag"
 
 [dependencies]
+proc-macro-crate = "1.1.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -12,33 +12,18 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 #[derive(Copy, Clone)]
-pub(crate) struct Mode {
+pub struct Mode {
     ser: bool,
     de: bool,
 }
 
-#[proc_macro_attribute]
-pub fn serde(args: TokenStream, input: TokenStream) -> TokenStream {
-    let ser = true;
-    let de = true;
-    expand(args, input, Mode { ser, de })
+impl Mode {
+    pub fn new(ser: bool, de: bool) -> Self {
+        Mode { ser, de }
+    }
 }
 
-#[proc_macro_attribute]
-pub fn serialize(args: TokenStream, input: TokenStream) -> TokenStream {
-    let ser = true;
-    let de = false;
-    expand(args, input, Mode { ser, de })
-}
-
-#[proc_macro_attribute]
-pub fn deserialize(args: TokenStream, input: TokenStream) -> TokenStream {
-    let ser = false;
-    let de = true;
-    expand(args, input, Mode { ser, de })
-}
-
-fn expand(args: TokenStream, input: TokenStream, mode: Mode) -> TokenStream {
+pub fn expand(args: TokenStream, input: TokenStream, mode: Mode) -> TokenStream {
     let input = parse_macro_input!(input as Input);
 
     TokenStream::from(match input {

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "typetag-impl"
+name = "typetag-macro"
 version = "0.2.3"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 description = "Implementation detail of the typetag crate"
@@ -8,10 +8,13 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/typetag"
 
+[lib]
+proc-macro = true
+
 [dependencies]
 proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+typetag-impl = { version = "=0.2.3", path = "../impl" }
+
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,19 +1,21 @@
 use proc_macro::TokenStream;
 
-use typetag_impl::{Mode, expand};
+use typetag_impl::{Mode, expand, get_crate_path};
 
 #[proc_macro_attribute]
 pub fn serde(args: TokenStream, input: TokenStream) -> TokenStream {
-    expand(args, input, Mode::new(true, true))
+    let crate_path = get_crate_path("typetag");
+    expand(args, input, Mode::new(true, true), &crate_path)
 }
 
 #[proc_macro_attribute]
 pub fn serialize(args: TokenStream, input: TokenStream) -> TokenStream {
-    expand(args, input, Mode::new(true, false))
+    let crate_path = get_crate_path("typetag");
+    expand(args, input, Mode::new(true, false), &crate_path)
 }
 
 #[proc_macro_attribute]
 pub fn deserialize(args: TokenStream, input: TokenStream) -> TokenStream {
-    expand(args, input, Mode::new(false, true))
+    let crate_path = get_crate_path("typetag");
+    expand(args, input, Mode::new(false, true), &crate_path)
 }
-

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,0 +1,19 @@
+use proc_macro::TokenStream;
+
+use typetag_impl::{Mode, expand};
+
+#[proc_macro_attribute]
+pub fn serde(args: TokenStream, input: TokenStream) -> TokenStream {
+    expand(args, input, Mode::new(true, true))
+}
+
+#[proc_macro_attribute]
+pub fn serialize(args: TokenStream, input: TokenStream) -> TokenStream {
+    expand(args, input, Mode::new(true, false))
+}
+
+#[proc_macro_attribute]
+pub fn deserialize(args: TokenStream, input: TokenStream) -> TokenStream {
+    expand(args, input, Mode::new(false, true))
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,6 @@
 )]
 
 extern crate alloc;
-
 mod adjacently;
 mod content;
 mod de;
@@ -315,7 +314,7 @@ mod ser;
 
 use self::__private as private;
 
-pub use typetag_impl::{deserialize, serde, serialize};
+pub use typetag_macro::{deserialize, serde, serialize};
 
 // Object-safe trait bound inserted by typetag serialization. We want this just
 // so the serialization requirement appears on rustdoc's view of your trait.


### PR DESCRIPTION
The proc macros in typetag explicitly use the `typetag` crate when referring to idents in the crate, this PR moves to using a `crate_path` variable instead. The variable is set by the `proc-macro-crate` package, which looks up the proper name of the crate in the Cargo.toml file. This allows the crate to be renamed in the Cargo.toml file, and still function.

This PR also breaks the macro definitions and their impl apart into separate crates, which allows other packages to easily re-export the macro without requiring users of their package to also depend on typetag directly.

This PR came about because I want to re-export the typetag macros from my crate, so my macros can use it, without the user of my crate needing to depend directly on typetag too.

I realize dtolnay has more context into these issues than I do hah, but for others here is a bit more context - https://internals.rust-lang.org/t/rfc-crate-for-proc-macro/16968
Also I very loosely based my solution on Bevy's, though using proc-macro-crate instead of rolling my own like they needed to. See the [bevy-derive](https://github.com/bevyengine/bevy/blob/main/crates/bevy_derive/src/lib.rs) and [bevy-macro-utils](https://github.com/bevyengine/bevy/blob/main/crates/bevy_macro_utils/src/lib.rs) crates for reference.

#### Example renaming crate in `Cargo.toml`:
`Cargo.toml`
```toml
[package]
name = "example"
version = "0.1.0"
edition = "2021"

[dependencies]
serde = { version = "1.0.140", features = ["derive"] }
serde_json = "1.0.82"
typetag_blah = { version = "0.2.1", package = "typetag" }
```
`main.rs`
```rust
[package]
name = "example"
version = "0.1.0"
edition = "2021"

[dependencies]
serde = { version = "1.0.140", features = ["derive"] }
serde_json = "1.0.82"
typetag_blah = { version = "0.2.1", package = "typetag" }
```


#### Example re-exporting macros:
`another-package/derive/src/lib.rs`
```rust
use proc_macro::TokenStream;
use quote::format_ident;
use typetag_impl::{Mode, expand, get_crate_path};

#[proc_macro_attribute]
pub fn serde(args: TokenStream, input: TokenStream) -> TokenStream {
    let mut crate_path = get_crate_path("another_package");
    crate_path.segments.push(format_ident!("typetag").into());
    expand(args, input, Mode::new(true, true), &crate_path)
}

#[proc_macro_attribute]
pub fn serialize(args: TokenStream, input: TokenStream) -> TokenStream {
    let mut crate_path = get_crate_path("another_package");
    crate_path.segments.push(format_ident!("typetag").into());
    expand(args, input, Mode::new(true, false), &crate_path)
}

#[proc_macro_attribute]
pub fn deserialize(args: TokenStream, input: TokenStream) -> TokenStream {
    let mut crate_path = get_crate_path("another_package");
    crate_path.segments.push(format_ident!("typetag").into());
    expand(args, input, Mode::new(false, true), &crate_path)
}
```
