### PR TITLE
Simplify deserialization of deserialize_fn from default variant using map_lookup

### DIFF
--- a/src/adjacently.rs
+++ b/src/adjacently.rs
@@ -138,20 +138,10 @@ impl<'de, T: ?Sized> Visitor<'de> for TaggedVisitor<T> {
                     // There is no second key.
                     None => {
                         if let Some(variant) = self.default_variant {
-                            // No variant is specified but there is a default variant.
-                            if let Some(Some(deserialize_fn)) = self.registry.map.get(variant) {
-                                let fn_apply = FnApply {
-                                    deserialize_fn: *deserialize_fn,
-                                };
-                                let content = content.into_deserializer();
-                                fn_apply.deserialize(content)?
-                            } else {
-                                // The default variant is not found in the registry.
-                                return Err(de::Error::unknown_variant(
-                                    variant,
-                                    &self.registry.names,
-                                ));
-                            }
+                            let deserialize_fn = map_lookup.visit_str(variant)?;
+                            let fn_apply = FnApply { deserialize_fn };
+                            let content = content.into_deserializer();
+                            fn_apply.deserialize(content)?
                         } else {
                             // No variant is specified and there is no default variant.
                             return Err(de::Error::missing_field(self.tag));

--- a/src/internally.rs
+++ b/src/internally.rs
@@ -115,13 +115,7 @@ impl<'de, T: ?Sized> Visitor<'de> for TaggedVisitor<T> {
         let deserialize_fn = match deserialize_fn {
             Some(deserialize_fn) => deserialize_fn,
             None => match self.default_variant {
-                Some(variant) => {
-                    if let Some(Some(deserialize_fn)) = self.registry.map.get(variant) {
-                        *deserialize_fn
-                    } else {
-                        return Err(de::Error::unknown_variant(variant, &self.registry.names));
-                    }
-                }
+                Some(variant) => map_lookup.visit_str(variant)?,
                 None => return Err(de::Error::missing_field(self.tag)),
             },
         };


### PR DESCRIPTION
Followup from #55.