### PR TITLE
Update to erased-serde 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.62"
 members = ["impl"]
 
 [dependencies]
-erased-serde = { version = "=0.4.0-rc.1", default-features = false, features = ["alloc"] }
+erased-serde = { version = "0.4", default-features = false, features = ["alloc"] }
 inventory = "0.3.10"
 once_cell = { version = "1.18", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.166", default-features = false, features = ["alloc", "derive"] }


### PR DESCRIPTION
Release notes: https://github.com/dtolnay/erased-serde/releases/tag/0.4.0