### PR TITLE
Don't repeat the tag in internally tagged structs which also have #[serde(tag)]

### DIFF
--- a/src/is_serialize_str.rs
+++ b/src/is_serialize_str.rs
@@ -284,3 +284,14 @@ impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
         self.unexpected()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_serialize_str() {
+        assert!(is_serialize_str("hello", "hello"));
+        assert!(!is_serialize_str("hello", "bye"));
+    }
+}

--- a/src/is_serialize_str.rs
+++ b/src/is_serialize_str.rs
@@ -1,0 +1,286 @@
+/// Check if a Serialize is a specific &'static str.
+/// This is done by implementing a Serializer whose entire purpose is to check whether a single
+/// method, serialize_str, is called with a given string.
+use core::fmt::Error;
+use serde::{ser, Serialize};
+
+pub fn is_serialize_str<T: ?Sized + Serialize>(value: &T, expected_str: &'static str) -> bool {
+    let mut ser = Serializer::new(expected_str);
+    let _ = value.serialize(&mut ser);
+    ser.state == GotExpectedStr
+}
+
+#[derive(PartialEq)]
+enum SerializerState {
+    Start,
+    GotExpectedStr,
+    GotUnexpected,
+}
+
+use SerializerState::*;
+
+struct Serializer {
+    pub expected_str: &'static str,
+    pub state: SerializerState,
+}
+
+impl Serializer {
+    fn new(expected_str: &'static str) -> Serializer {
+        Serializer {
+            expected_str,
+            state: Start,
+        }
+    }
+
+    fn unexpected(&mut self) -> Res {
+        self.state = GotUnexpected;
+        Ok(())
+    }
+
+    fn unexpected2(&mut self) -> Result<&mut Self, Error> {
+        self.state = GotUnexpected;
+        Ok(self)
+    }
+}
+
+type Res = Result<(), Error>;
+
+impl<'a> ser::Serializer for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, _: bool) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_i8(self, _: i8) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_i16(self, _: i16) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_i32(self, _: i32) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_i64(self, _: i64) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_u8(self, _: u8) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_u16(self, _: u16) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_u32(self, _: u32) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_u64(self, _: u64) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_f32(self, _: f32) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_f64(self, _: f64) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_char(self, _: char) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_str(self, v: &str) -> Res {
+        if self.state == Start && v == self.expected_str {
+            self.state = GotExpectedStr;
+        } else {
+            self.state = GotUnexpected;
+        }
+        Ok(())
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_none(self) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_unit(self) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(self, _: &'static str, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_newtype_variant<T>(self, _: &'static str, _: u32, _: &'static str, _: &T) -> Res
+    where
+        T: ?Sized + Serialize,
+    {
+        self.unexpected()
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+
+    fn serialize_tuple_struct(self, _: &'static str, _: usize) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+
+    fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self, Error> {
+        self.unexpected2()
+    }
+}
+
+impl<'a> ser::SerializeSeq for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}
+
+impl<'a> ser::SerializeTuple for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}
+
+impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}
+
+impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}
+
+impl<'a> ser::SerializeMap for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}
+
+impl<'a> ser::SerializeStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &'static str, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}
+
+impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &'static str, _: &T) -> Res {
+        self.unexpected()
+    }
+
+    fn end(self) -> Res {
+        self.unexpected()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,7 @@ mod content;
 mod de;
 mod externally;
 mod internally;
+mod is_serialize_str;
 mod ser;
 
 use self::__private as private;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,4 +1,5 @@
 use crate::internally::DEFAULT_KEY;
+use crate::is_serialize_str::is_serialize_str;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -234,7 +235,7 @@ where
     ) -> Result<Self::SerializeStruct, Self::Error> {
         let mut state = self.delegate.serialize_map(Some(len + 1))?;
         state.serialize_entry(self.tag, self.variant)?;
-        Ok(SerializeStructAsMap::new(state, self.tag))
+        Ok(SerializeStructAsMap::new(state, self.tag, self.variant))
     }
 
     fn serialize_struct_variant(
@@ -388,11 +389,12 @@ where
 pub struct SerializeStructAsMap<M> {
     map: M,
     tag: &'static str,
+    variant: &'static str,
 }
 
 impl<M> SerializeStructAsMap<M> {
-    fn new(map: M, tag: &'static str) -> Self {
-        SerializeStructAsMap { map, tag }
+    fn new(map: M, tag: &'static str, variant: &'static str) -> Self {
+        SerializeStructAsMap { map, tag, variant }
     }
 }
 
@@ -408,8 +410,7 @@ where
         T: ?Sized + Serialize,
     {
         if key == self.tag {
-            // I would have liked to require value to be a &str or String, and equal to
-            // the variant, but I don't know how to do it without specialization.
+            assert!(is_serialize_str(value, self.variant));
             Ok(())
         } else {
             self.map.serialize_entry(key, value)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,6 +12,12 @@ struct B {
     b: u8,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+struct C {
+    c: u8,
+}
+
 mod externally_tagged {
     use super::{A, B};
 
@@ -66,7 +72,7 @@ mod externally_tagged {
 }
 
 mod internally_tagged {
-    use super::{A, B};
+    use super::{A, B, C};
 
     #[typetag::serde(tag = "type")]
     trait Trait {
@@ -94,11 +100,29 @@ mod internally_tagged {
         }
     }
 
+    #[typetag::serde]
+    impl Trait for C {
+        fn assert_a_is_11(&self) {
+            panic!("is not A!");
+        }
+        fn assert_b_is_11(&self) {
+            panic!("is not B!");
+        }
+    }
+
     #[test]
     fn test_json_serialize() {
         let trait_object = &A { a: 11 } as &dyn Trait;
         let json = serde_json::to_string(trait_object).unwrap();
         let expected = r#"{"type":"A","a":11}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn test_json_serialize_with_serde_tag() {
+        let trait_object = &C { c: 11 } as &dyn Trait;
+        let json = serde_json::to_string(trait_object).unwrap();
+        let expected = r#"{"type":"C","c":11}"#;
         assert_eq!(json, expected);
     }
 


### PR DESCRIPTION
When a struct uses `#[serde(tag)]` and also internally-tagged typetag, currently when serializing, the tag appears twice in the resulting JSON - one time it is added by typetag and one time by serde.

This MR makes InternallyTaggedSerializer output just a single tag entry. It does so by adding a check to serialize_field(), that if the key is the tag, it doesn't continue to serialize the field. In debug mode, it will also assert that the value is the same as was already written.

I needed this to implement https://github.com/DeterminateSystems/nix-installer/issues/1062 - I wanted to have a tag field for all "Action" entries in the json, even though some were `dyn Action` and some were plain structs which implement `Action`. Without this change, the tag entries would appear twice, so the JSON would be broken. To make it clearer, here's the change in the JSON that the mentioned issue suggests:
![image](https://github.com/user-attachments/assets/45d8c398-f622-45c7-9515-667ddd121c8d)

What do you think?

Thanks!
Noam