### PR TITLE
Add check to allow sized assoc types

### DIFF
--- a/impl/src/parse.rs
+++ b/impl/src/parse.rs
@@ -1,6 +1,9 @@
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
-use syn::{Attribute, Error, ImplItem, ItemImpl, ItemTrait, LitStr, Token, TraitItem, Visibility};
+use syn::{
+    Attribute, Error, ImplItem, ItemImpl, ItemTrait, LitStr, Token, TraitItem, Type,
+    TypeParamBound, Visibility, WherePredicate,
+};
 
 mod kw {
     syn::custom_keyword!(tag);
@@ -51,11 +54,37 @@ impl Parse for Input {
                     let msg = "typetag trait with associated const is not supported yet";
                     return Err(Error::new_spanned(span, msg));
                 } else if let TraitItem::Type(assoc) = assoc {
-                    let type_token = assoc.type_token;
-                    let semi_token = assoc.semi_token;
-                    let span = quote!(#type_token #semi_token);
-                    let msg = "typetag trait with associated type is not supported yet";
-                    return Err(Error::new_spanned(span, msg));
+                    let mut valid_assoc = false;
+
+                    // Check if Self: Sized happens to be in where clause
+                    if assoc.generics.where_clause.is_some() {
+                        let where_clause = assoc.generics.where_clause.as_ref().unwrap();
+                        for predicate in &where_clause.predicates {
+                            if let WherePredicate::Type(pred_type) = predicate {
+                                // Type should be self
+                                if let Type::Path(type_path) = &pred_type.bounded_ty {
+                                    if type_path.path.is_ident("Self") {
+                                        for bound in &pred_type.bounds {
+                                            if let TypeParamBound::Trait(trait_bound) = bound {
+                                                if trait_bound.path.is_ident("Sized") {
+                                                    valid_assoc = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if !valid_assoc {
+                        let type_token = assoc.type_token;
+                        let semi_token = assoc.semi_token;
+                        let span = quote!(#type_token #semi_token);
+                        let msg = "typetag trait with associated type is not supported yet";
+                        return Err(Error::new_spanned(span, msg));
+                    }
                 }
             }
             attrs.extend(item.attrs);
@@ -76,12 +105,6 @@ impl Parse for Input {
                     let semi_token = assoc.semi_token;
                     let span = quote!(#const_token #semi_token);
                     let msg = "typetag trait with associated const is not supported yet";
-                    return Err(Error::new_spanned(span, msg));
-                } else if let ImplItem::Type(assoc) = assoc {
-                    let type_token = assoc.type_token;
-                    let semi_token = assoc.semi_token;
-                    let span = quote!(#type_token #semi_token);
-                    let msg = "typetag trait with associated type is not supported yet";
                     return Err(Error::new_spanned(span, msg));
                 }
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -606,3 +606,15 @@ mod async_traits {
         async fn f(&self) {}
     }
 }
+
+mod self_sized {
+    #[test]
+    fn good_assoc() {
+        #[typetag::serialize]
+        trait TraitFine {
+            type AssocType
+            where
+                Self: Sized;
+        }
+    }
+}


### PR DESCRIPTION
While most associated types are not dyn-compatible, they can be when bounded by `Self: Sized`. This PR allows such associated types to work with typetag. It additionally removes the check on the impl block for associated types.

As an example, this now functions properly
```rust
#[typetag::serde]
trait MyTrait {
    type MyType
    where
        Self: Sized;
}

#[derive(serde::Serialize, serde::Deserialize)]
struct MyStruct;

#[typetag::serde]
impl MyTrait for MyStruct {
    type MyType = i32;
}
```

Note, I'm fairly new to `syn`, so if there's an easier way to check for `Self: Sized`, I'm happy to tweak it to clean it up.