### PR TITLE
Disable `Self: Sized` associated type test on rustc older than 1.74

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -607,6 +607,7 @@ mod async_traits {
     }
 }
 
+#[rustversion::since(1.74)]
 mod self_sized {
     #[test]
     fn good_assoc() {


### PR DESCRIPTION
Fixes https://github.com/dtolnay/typetag/pull/91#issuecomment-2546881387.