### PR TITLE
Improve compile error message for trait with associated type with `Self: Sized`

### DIFF
--- a/impl/src/parse.rs
+++ b/impl/src/parse.rs
@@ -58,7 +58,7 @@ impl Parse for Input {
                         let type_token = assoc.type_token;
                         let semi_token = assoc.semi_token;
                         let span = quote!(#type_token #semi_token);
-                        let msg = "typetag trait with associated type is not supported yet";
+                        let msg = "typetag trait with associated type without bound `Self: Sized` is unsupported yet";
                         return Err(Error::new_spanned(span, msg));
                     }
                 }

--- a/tests/ui/associated-type.stderr
+++ b/tests/ui/associated-type.stderr
@@ -1,4 +1,4 @@
-error: typetag trait with associated type is not supported yet
+error: typetag trait with associated type without bound `Self: Sized` is unsupported yet
  --> tests/ui/associated-type.rs:3:5
   |
 3 |     type Assoc;


### PR DESCRIPTION
Motivation:

Currently typetag allows associated type with `Self: Sized` boundary, but the error message is not verbose enough to provide such information. It mislead users to assume there is no way to define associated types at all.

Change:

This improves error message so that users can know it can be supported with proper boundary, so they can decide whether they add type boundary or go other ways to implement.