### PR TITLE
feat(name): accept a constant expression for impl tag name (#74)

### DIFF
--- a/impl/src/parse.rs
+++ b/impl/src/parse.rs
@@ -1,8 +1,8 @@
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{
-    Attribute, Error, Generics, ImplItem, ItemImpl, ItemTrait, LitStr, Token, TraitItem, Type,
-    TypeParamBound, Visibility, WherePredicate,
+    Attribute, Error, Expr, Generics, ImplItem, ItemImpl, ItemTrait, LitStr, Token, TraitItem,
+    Type, TypeParamBound, Visibility, WherePredicate,
 };
 
 mod kw {
@@ -28,7 +28,7 @@ pub enum TraitArgs {
 }
 
 pub struct ImplArgs {
-    pub name: Option<LitStr>,
+    pub name: Option<Expr>,
 }
 
 pub enum Input {
@@ -169,6 +169,7 @@ impl Parse for TraitArgs {
 
 // #[typetag::serde]
 // #[typetag::serde(name = "Tag")]
+// #[typetag::serde(name = CONSTANT)]
 impl Parse for ImplArgs {
     fn parse(input: ParseStream) -> Result<Self> {
         let name = if input.is_empty() {
@@ -176,9 +177,9 @@ impl Parse for ImplArgs {
         } else {
             input.parse::<kw::name>()?;
             input.parse::<Token![=]>()?;
-            let name: LitStr = input.parse()?;
+            let expr: Expr = input.parse()?;
             input.parse::<Option<Token![,]>>()?;
-            Some(name)
+            Some(expr)
         };
         Ok(ImplArgs { name })
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -570,6 +570,58 @@ mod tag_mismatch {
     }
 }
 
+mod const_name {
+    use super::{A, B};
+
+    const A_TAG: &str = "AConst";
+
+    #[typetag::serde]
+    trait Trait {
+        fn assert_a_is_11(&self);
+        fn assert_b_is_11(&self);
+    }
+
+    #[typetag::serde(name = A_TAG)]
+    impl Trait for A {
+        fn assert_a_is_11(&self) {
+            assert_eq!(self.a, 11);
+        }
+        fn assert_b_is_11(&self) {
+            panic!("is not B!");
+        }
+    }
+
+    #[typetag::serde(name = "BLit")]
+    impl Trait for B {
+        fn assert_a_is_11(&self) {
+            panic!("is not A!");
+        }
+        fn assert_b_is_11(&self) {
+            assert_eq!(self.b, 11);
+        }
+    }
+
+    #[test]
+    fn test_const_tag_json_round_trip() {
+        let trait_object = &A { a: 11 } as &dyn Trait;
+        let json = serde_json::to_string(trait_object).unwrap();
+        let expected = r#"{"AConst":{"a":11}}"#;
+        assert_eq!(json, expected);
+        let trait_object: Box<dyn Trait> = serde_json::from_str(json.as_str()).unwrap();
+        trait_object.assert_a_is_11();
+    }
+
+    #[test]
+    fn test_string_literal_name_still_works() {
+        let trait_object = &B { b: 11 } as &dyn Trait;
+        let json = serde_json::to_string(trait_object).unwrap();
+        let expected = r#"{"BLit":{"b":11}}"#;
+        assert_eq!(json, expected);
+        let trait_object: Box<dyn Trait> = serde_json::from_str(json.as_str()).unwrap();
+        trait_object.assert_b_is_11();
+    }
+}
+
 mod async_traits {
     use async_trait::async_trait;
     use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Closes #74. You said "Yes, I would accept a PR for this." Parses the `name = ...` value as an `Expr` so a `const X: &str` path works in addition to a string literal, allowing the user to keep the tag name in a shared constant.